### PR TITLE
Task/js/misc minor changes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, Request
@@ -15,11 +16,11 @@ from app.settings import *
 
 
 class Configuration(BaseModel):
-    lat: float = Field()
-    lon: float = Field()
-    config_file: str = Field()
-    pio_env: str = Field()
-    release_version: str = Field()
+    approx_lat: float = Field()
+    approx_lon: float = Field()
+    config_file: Optional[str] = Field()
+    pio_env: Optional[str] = Field()
+    release_version: Optional[str] = Field()
     uuid: str = Field()
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -2,9 +2,9 @@ from mongoengine import *
 
 
 class Configuration(Document):
-    lat = FloatField(min_value=-90, max_value=90)
-    lon = FloatField(min_value=-180, max_value=180)
-    config_file = StringField()
-    pio_env = StringField()
-    release_version = StringField()
+    approx_lat = FloatField(min_value=-90, max_value=90)
+    approx_lon = FloatField(min_value=-180, max_value=180)
+    config_file = StringField(default='', null=True)
+    pio_env = StringField(default='', null=True)
+    release_version = StringField(default='', null=True)
     uuid = StringField()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,11 @@ services:
     image: mongo-express
     ports:
       - "8888:8081"
+    restart: unless-stopped
     environment:
       ME_CONFIG_MONGODB_SERVER: mongo
       ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_MONGODB_ENABLE_ADMIN: true
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: "true"
       ME_CONFIG_MONGODB_AUTH_DATABASE: admin
       ME_CONFIG_MONGODB_AUTH_USERNAME: ${MONGO_ROOT_USER}
       ME_CONFIG_MONGODB_AUTH_PASSWORD: ${MONGO_ROOT_PASSWORD}
@@ -33,3 +34,4 @@ services:
       ME_CONFIG_BASICAUTH_PASSWORD: ${MONGO_EXPRESS_PASSWORD}
     depends_on:
       - mongo
+


### PR DESCRIPTION
- Changed `lat`/`lon` to `approx_lat`/`approx_lon`
  - More technically correct (since we round user location to be less precise) and to add assurance to any user that sees the data
- Made `config_file`, `pio_env`, `release_version` optional (default to `''`)
  - Reasoning is that we want as much data as possible, so if there's any errors in the data (for whatever reason) we can still get _some_ metrics out of that entry
  - e.g. `release_version` is null, but we still get info that the user was using `ramps` at 63 deg N, etc
- Stringified `ME_CONFIG_MONGODB_ENABLE_ADMIN: "true"`
  - it was giving me an error when I ran it :woman_shrugging:
- Added `restart: unless-stopped` to `mongo-express`
  - For me `mongo-express` would start up before `mongo` and complain that it couldn't connect (then exit). Now it'll automatically try to restart unless you manually stop the container