### PR TITLE
Task/js/change UUID key

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ class Configuration(BaseModel):
     config_file: Optional[str] = Field()
     pio_env: Optional[str] = Field()
     release_version: Optional[str] = Field()
-    uuid: str = Field()
+    host_uuid: str = Field()
 
 
 app = FastAPI()

--- a/app/models.py
+++ b/app/models.py
@@ -7,4 +7,4 @@ class Configuration(Document):
     config_file = StringField(default='', null=True)
     pio_env = StringField(default='', null=True)
     release_version = StringField(default='', null=True)
-    uuid = StringField()
+    host_uuid = StringField()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   config:
     build: .
     image: config-server
+    restart: unless-stopped
     ports:
       - "8000:80"
     environment:
@@ -13,6 +14,7 @@ services:
 
   mongo:
     image: mongo
+    restart: unless-stopped
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}


### PR DESCRIPTION
- Rename `uuid` to `computer_uuid`, we may have other uuids in the future. Just because we talked about maybe having per-OAT ids sometime later
- Added auto-restart to the other services